### PR TITLE
Increases numeric precision of sound effect 'length in milliseconds' …

### DIFF
--- a/intervalmusiccompositor.app/src/main/resources/CHANGELOG.txt
+++ b/intervalmusiccompositor.app/src/main/resources/CHANGELOG.txt
@@ -4,6 +4,7 @@ retorte laboratories (retorte.ch) IntervalMusicCompositor change log
 2025-xx-xx  2.11.7
 --------------------------------------------------------------------------------
 FIX  #81    Fixes occasional crash when opening output directory chooser.
+FIX  #82    Fixes short white noise after every 'double whistle' sound effect.
 
 
 2023-12-11  2.11.6

--- a/intervalmusiccompositor.commons.audio/src/main/java/ch/retorte/intervalmusiccompositor/commons/audio/AudioStreamUtil.java
+++ b/intervalmusiccompositor.commons.audio/src/main/java/ch/retorte/intervalmusiccompositor/commons/audio/AudioStreamUtil.java
@@ -12,24 +12,19 @@ import java.io.InputStream;
  */
 public class AudioStreamUtil {
 
+  // ---- Methods
 
-
-  public AudioInputStream audioInputStreamFrom(InputStream inputStream) throws IOException, UnsupportedAudioFileException {
-    return new WaveAudioFileReader().getAudioInputStream(inputStream);
+  /**
+   * Determines the length of a {@link InputStream} in milliseconds. For better precision we represent them as double.
+   */
+  public double lengthInMillisecondsOf(InputStream inputStream) {
+    AudioInputStream audioInputStream = audioInputStreamFromWaveInputStream(inputStream);
+    return getStreamLengthInMillisecondsOf(audioInputStream);
   }
 
   /**
-   * Determines the length of a {@link AudioInputStream}.
+   * Converts the provided {@link InputStream} to a {@link AudioInputStream} but converts any checked exception to a {@link RuntimeException}.
    */
-  private long getStreamLengthInMilliSecondsOf(AudioInputStream audioInputStream) {
-    return (long) ((audioInputStream.getFrameLength() / audioInputStream.getFormat().getFrameRate()) * 1000);
-  }
-
-  public long lengthInMillisOf(InputStream inputStream) {
-    AudioInputStream audioInputStream = audioInputStreamFromWaveInputStream(inputStream);
-    return getStreamLengthInMilliSecondsOf(audioInputStream);
-  }
-
   private AudioInputStream audioInputStreamFromWaveInputStream(InputStream inputStream) {
     try {
       return audioInputStreamFrom(inputStream);
@@ -39,4 +34,17 @@ public class AudioStreamUtil {
     }
   }
 
+  /**
+   * Converts the provided {@link InputStream} to a {@link AudioInputStream}.
+   */
+  public AudioInputStream audioInputStreamFrom(InputStream inputStream) throws IOException, UnsupportedAudioFileException {
+    return new WaveAudioFileReader().getAudioInputStream(inputStream);
+  }
+
+  /**
+   * Determines the length of a {@link AudioInputStream} in milliseconds. For better precision we represent them as double.
+   */
+  private double getStreamLengthInMillisecondsOf(AudioInputStream audioInputStream) {
+    return audioInputStream.getFrameLength() * 1000 / audioInputStream.getFormat().getFrameRate();
+  }
 }

--- a/intervalmusiccompositor.core/src/main/java/ch/retorte/intervalmusiccompositor/playlist/PlaylistReport.java
+++ b/intervalmusiccompositor.core/src/main/java/ch/retorte/intervalmusiccompositor/playlist/PlaylistReport.java
@@ -222,14 +222,14 @@ public class PlaylistReport {
 
         for (SoundEffectOccurrence s : sortByStartTime(p.getSoundEffects())) {
 
-          builder.append(formatTime.getStrictFormattedTime((totalTimeMs + s.getTimeMillis()) / 1000.0));
+          builder.append(formatTime.getStrictFormattedTime((totalTimeMs + s.getStartTimeMs()) / 1000.0));
 
           builder.append(", ");
 
           builder.append("[");
           builder.append(durationString);
           builder.append(" ");
-          double extractDurationInSeconds = s.getSoundEffect().getDisplayDurationMillis() / 1000.0;
+          double extractDurationInSeconds = s.getSoundEffect().getDisplayDurationMs() / 1000.0;
           builder.append(formatTime.getStrictFormattedTime(extractDurationInSeconds));
           builder.append("]");
 
@@ -249,7 +249,7 @@ public class PlaylistReport {
 
   private List<SoundEffectOccurrence> sortByStartTime(List<SoundEffectOccurrence> soundEffectOccurrences) {
     List<SoundEffectOccurrence> result = newArrayList(soundEffectOccurrences);
-    result.sort(comparingLong(SoundEffectOccurrence::getTimeMillis));
+    result.sort(comparingLong(SoundEffectOccurrence::getStartTimeMs));
     return result;
   }
 

--- a/intervalmusiccompositor.core/src/main/java/ch/retorte/intervalmusiccompositor/util/SoundHelper.java
+++ b/intervalmusiccompositor.core/src/main/java/ch/retorte/intervalmusiccompositor/util/SoundHelper.java
@@ -38,8 +38,8 @@ public class SoundHelper implements AudioStandardizer, ByteArrayConverter {
   }
 
   /**
-   * Determines the largest average frame value of a audio stream. Uses a 16
-   * bytes window as smallest unit. May be expanded through the windows
+   * Determines the largest average frame value of an audio stream. Uses a 16
+   * bytes window as smallest unit. May be expanded through the sampleWindow
    * argument.
    * 
    * @param inputBuffer
@@ -69,7 +69,7 @@ public class SoundHelper implements AudioStandardizer, ByteArrayConverter {
 
       if (numberOfBytesRead == numberOfBytes) {
 
-        // Here we do a roll out to speed up the whole thing
+        // Here we do a roll-out to speed up the whole thing
         sample = Math.abs((audioBytes[0] & 0xFF) | (audioBytes[1] << 8));
         sample += Math.abs((audioBytes[2] & 0xFF) | (audioBytes[3] << 8));
         sample += Math.abs((audioBytes[4] & 0xFF) | (audioBytes[5] << 8));
@@ -159,8 +159,8 @@ public class SoundHelper implements AudioStandardizer, ByteArrayConverter {
   }
 
   public byte[] getExtract(byte[] data, long startMs, long durationMs) {
-    long startBytes = getSamplesFromSeconds(startMs / 1000.0);
-    long durationBytes = getSamplesFromSeconds(durationMs / 1000.0);
+    long startBytes = getSamplesFromMilliseconds(startMs);
+    long durationBytes = getSamplesFromMilliseconds(durationMs);
     byte[] result = new byte[(int) durationBytes];
 
     System.arraycopy(data, (int) startBytes, result, 0, result.length);
@@ -206,8 +206,8 @@ public class SoundHelper implements AudioStandardizer, ByteArrayConverter {
     return byteLength;
   }
 
-  public byte[] generateSilenceOfLength(double lengthInSeconds) {
-    int samples = getSamplesFromSeconds(lengthInSeconds);
+  public byte[] generateSilenceOfLength(double lengthInMs) {
+    int samples = getSamplesFromMilliseconds(lengthInMs);
 
     byte[] silenceBuffer = new byte[samples];
     for (int i = 0; i < silenceBuffer.length; i = i + 2) {
@@ -218,8 +218,8 @@ public class SoundHelper implements AudioStandardizer, ByteArrayConverter {
     return silenceBuffer;
   }
 
-  public int getSamplesFromSeconds(double seconds) {
-    return (int) (seconds * SAMPLE_RATE * TARGET_AUDIO_FORMAT.getFrameSize());
+  public int getSamplesFromMilliseconds(double milliseconds) {
+    return (int) (milliseconds * SAMPLE_RATE * TARGET_AUDIO_FORMAT.getFrameSize()) / 1000;
   }
 
   public AudioInputStream getStreamExtract(AudioInputStream ais, int start, int length) {
@@ -257,12 +257,12 @@ public class SoundHelper implements AudioStandardizer, ByteArrayConverter {
 
   /**
    * Fades the provided sample array in at the start and out at the end. The respective fading part length is determined
-   * by the blendTime argument. Additionally a blend factor can be specified which denots how the blending should be scaled.
+   * by the blendTime argument. Additionally, a blend factor can be specified which denotes how the blending should be scaled.
    */
-  public byte[] doubleSidedLinearBlend(byte[] sampleByteArray, double blendTime, double startFactor, double endFactor) {
+  public byte[] doubleSidedLinearBlend(byte[] sampleByteArray, double blendTimeMs, double startFactor, double endFactor) {
 
     int sampleLength = sampleByteArray.length;
-    int blendSamples = getSamplesFromSeconds(blendTime);
+    int blendSamples = getSamplesFromMilliseconds(blendTimeMs);
     double factorPerSample = (endFactor - startFactor) / blendSamples;
 
     if (((double) sampleByteArray.length / 2) < blendSamples) {

--- a/intervalmusiccompositor.core/src/test/java/ch/retorte/intervalmusiccompositor/playlist/PlaylistTest.java
+++ b/intervalmusiccompositor.core/src/test/java/ch/retorte/intervalmusiccompositor/playlist/PlaylistTest.java
@@ -62,7 +62,7 @@ public class PlaylistTest {
         breakPattern = newArrayList();
         soundEffectOccurrences = newArrayList();
 
-        when(soundEffect1.getDurationMillis()).thenReturn(2000L);
+        when(soundEffect1.getDurationMs()).thenReturn(2000.0);
     }
 
     @Test
@@ -366,7 +366,7 @@ public class PlaylistTest {
         // then
         assertTrue(playlist.hasSoundEffects());
         List<SoundEffectOccurrence> soundEffects = playlist.iterator().next().getSoundEffects();
-        assertThat(soundEffects.get(0).getTimeMillis(), is(15000L));
+        assertThat(soundEffects.get(0).getStartTimeMs(), is(15000L));
     }
 
     @Test
@@ -384,7 +384,7 @@ public class PlaylistTest {
         // then
         assertTrue(playlist.hasSoundEffects());
         List<SoundEffectOccurrence> soundEffects = playlist.iterator().next().getSoundEffects();
-        assertThat(soundEffects.get(0).getTimeMillis(), is(6000L));
+        assertThat(soundEffects.get(0).getStartTimeMs(), is(6000L));
     }
 
     @Test
@@ -402,7 +402,7 @@ public class PlaylistTest {
         assertTrue(playlist.hasSoundEffects());
         List<SoundEffectOccurrence> soundEffects = playlist.iterator().next().getSoundEffects();
         assertThat(soundEffects.size(), is(1));
-        assertThat(soundEffects.get(0).getTimeMillis(), is(9000L));
+        assertThat(soundEffects.get(0).getStartTimeMs(), is(9000L));
     }
 
 

--- a/intervalmusiccompositor.model/src/main/java/ch/retorte/intervalmusiccompositor/model/soundeffect/SoundEffect.java
+++ b/intervalmusiccompositor.model/src/main/java/ch/retorte/intervalmusiccompositor/model/soundeffect/SoundEffect.java
@@ -11,8 +11,8 @@ public class SoundEffect {
 
   private final String id;
   private final String resource;
-  private final long effectiveDurationMillis;
-  private final long displayDurationMillis;
+  private final double effectiveDurationMs;
+  private final long displayDurationMs;
 
 
   //---- Constructor
@@ -22,14 +22,14 @@ public class SoundEffect {
    *
    * @param id human-readable identification string
    * @param resource reference to the 44100khz stereo WAV file holding the actual sound effect
-   * @param effectiveDurationMillis the length of the sound effect
-   * @param displayDurationMillis a 'nice' length value to be used for display purposes. If the actual length is 1920 ms, this could be set to 2000.
+   * @param effectiveDurationMs the length of the sound effect in ms, but as double value for increased precision.
+   * @param displayDurationMs a 'nice' length value to be used for display purposes. If the actual length is 1920 ms, this could be set to 2000.
    */
-  public SoundEffect(String id, String resource, long effectiveDurationMillis, long displayDurationMillis) {
+  public SoundEffect(String id, String resource, double effectiveDurationMs, long displayDurationMs) {
     this.id = id;
     this.resource = resource;
-    this.effectiveDurationMillis = effectiveDurationMillis;
-    this.displayDurationMillis = displayDurationMillis;
+    this.effectiveDurationMs = effectiveDurationMs;
+    this.displayDurationMs = displayDurationMs;
   }
 
 
@@ -43,16 +43,16 @@ public class SoundEffect {
     return this.getClass().getResourceAsStream(resource);
   }
 
-  public long getDurationMillis() {
-    return effectiveDurationMillis;
+  public double getDurationMs() {
+    return effectiveDurationMs;
   }
 
-  public long getDisplayDurationMillis() {
-    return displayDurationMillis;
+  public long getDisplayDurationMs() {
+    return displayDurationMs;
   }
 
   @Override
   public String toString() {
-    return id + " (" + displayDurationMillis + ")";
+    return id + " (" + displayDurationMs + ")";
   }
 }

--- a/intervalmusiccompositor.model/src/main/java/ch/retorte/intervalmusiccompositor/model/soundeffect/SoundEffectOccurrence.java
+++ b/intervalmusiccompositor.model/src/main/java/ch/retorte/intervalmusiccompositor/model/soundeffect/SoundEffectOccurrence.java
@@ -8,19 +8,24 @@ public class SoundEffectOccurrence {
   //---- Fields
 
   private SoundEffect soundEffect;
-  private long timeMillis;
+  private long startTimeMs;
 
 
   //---- Constructor
 
-  public SoundEffectOccurrence(SoundEffect soundEffect, long timeMillis) {
+  /**
+   * Creates a new sound effect occurrence.
+   *
+   * @param soundEffect the {@link SoundEffect} to be played.
+   * @param startTimeMs the time in milliseconds it should start playing.
+   */
+  public SoundEffectOccurrence(SoundEffect soundEffect, long startTimeMs) {
     this.soundEffect = soundEffect;
-    this.timeMillis = timeMillis;
+    this.startTimeMs = startTimeMs;
   }
 
 
   //---- Methods
-
 
   public SoundEffect getSoundEffect() {
     return soundEffect;
@@ -30,11 +35,11 @@ public class SoundEffectOccurrence {
     this.soundEffect = soundEffect;
   }
 
-  public long getTimeMillis() {
-    return timeMillis;
+  public long getStartTimeMs() {
+    return startTimeMs;
   }
 
-  public void setTimeMillis(long timeMillis) {
-    this.timeMillis = timeMillis;
+  public void setStartTimeMs(long startTimeMs) {
+    this.startTimeMs = startTimeMs;
   }
 }

--- a/intervalmusiccompositor.soundeffects/src/main/java/ch/retorte/intervalmusiccompositor/soundeffects/sounds/DoubleWhistleSoundEffect.java
+++ b/intervalmusiccompositor.soundeffects/src/main/java/ch/retorte/intervalmusiccompositor/soundeffects/sounds/DoubleWhistleSoundEffect.java
@@ -18,6 +18,6 @@ public class DoubleWhistleSoundEffect extends SoundEffect {
   //---- Constructor
 
   public DoubleWhistleSoundEffect() {
-    super(ID, RESOURCE, new AudioStreamUtil().lengthInMillisOf(DoubleWhistleSoundEffect.class.getResourceAsStream(RESOURCE)), DISPLAY_DURATION);
+    super(ID, RESOURCE, new AudioStreamUtil().lengthInMillisecondsOf(DoubleWhistleSoundEffect.class.getResourceAsStream(RESOURCE)), DISPLAY_DURATION);
   }
 }

--- a/intervalmusiccompositor.soundeffects/src/main/java/ch/retorte/intervalmusiccompositor/soundeffects/sounds/GongSoundEffect.java
+++ b/intervalmusiccompositor.soundeffects/src/main/java/ch/retorte/intervalmusiccompositor/soundeffects/sounds/GongSoundEffect.java
@@ -18,6 +18,6 @@ public class GongSoundEffect extends SoundEffect {
   //---- Constructor
 
   public GongSoundEffect() {
-    super(ID, RESOURCE, new AudioStreamUtil().lengthInMillisOf(GongSoundEffect.class.getResourceAsStream(RESOURCE)), DISPLAY_DURATION);
+    super(ID, RESOURCE, new AudioStreamUtil().lengthInMillisecondsOf(GongSoundEffect.class.getResourceAsStream(RESOURCE)), DISPLAY_DURATION);
   }
 }

--- a/intervalmusiccompositor.soundeffects/src/main/java/ch/retorte/intervalmusiccompositor/soundeffects/sounds/WhistleSoundEffect.java
+++ b/intervalmusiccompositor.soundeffects/src/main/java/ch/retorte/intervalmusiccompositor/soundeffects/sounds/WhistleSoundEffect.java
@@ -18,6 +18,6 @@ public class WhistleSoundEffect extends SoundEffect {
   //---- Constructor
 
   public WhistleSoundEffect() {
-    super(ID, RESOURCE, new AudioStreamUtil().lengthInMillisOf(WhistleSoundEffect.class.getResourceAsStream(RESOURCE)), DISPLAY_DURATION);
+    super(ID, RESOURCE, new AudioStreamUtil().lengthInMillisecondsOf(WhistleSoundEffect.class.getResourceAsStream(RESOURCE)), DISPLAY_DURATION);
   }
 }

--- a/intervalmusiccompositor.spi/src/main/java/ch/retorte/intervalmusiccompositor/spi/audio/AudioStandardizer.java
+++ b/intervalmusiccompositor.spi/src/main/java/ch/retorte/intervalmusiccompositor/spi/audio/AudioStandardizer.java
@@ -5,14 +5,17 @@ import javax.sound.sampled.AudioInputStream;
 
 /**
  * Normalizes an {@link AudioInputStream} so that it has standardized audio properties.
- * 
- * @author nw
  */
 public interface AudioStandardizer {
+
+  // ---- Statics
 
   float SAMPLE_RATE = 44100.0F;
   AudioFormat.Encoding TARGET_ENCODING = AudioFormat.Encoding.PCM_SIGNED;
   AudioFormat TARGET_AUDIO_FORMAT = new AudioFormat(TARGET_ENCODING, SAMPLE_RATE, 16, 2, 4, SAMPLE_RATE, false);
+
+
+  // ---- Methods
 
   /**
    * Standardizes the input stream to our desired format.

--- a/intervalmusiccompositor.ui.fx/src/main/java/ch/retorte/intervalmusiccompositor/ui/graphics/BarChart.java
+++ b/intervalmusiccompositor.ui.fx/src/main/java/ch/retorte/intervalmusiccompositor/ui/graphics/BarChart.java
@@ -168,8 +168,8 @@ public class BarChart {
           double width = soundPattern.get(j) * scale;
 
           for (SoundEffectOccurrence s : soundEffectOccurrences) {
-            double soundEffectPosition = s.getTimeMillis() / 1000.0 * scale;
-            double soundEffectWidth = s.getSoundEffect().getDisplayDurationMillis() / 1000.0 * scale;
+            double soundEffectPosition = s.getStartTimeMs() / 1000.0 * scale;
+            double soundEffectWidth = s.getSoundEffect().getDisplayDurationMs() / 1000.0 * scale;
 
             graphicsContext.setFill(soundEffectsColor);
             graphicsContext.fillRect(currentLeftBorder + soundEffectPosition, top, soundEffectWidth, image.getHeight() - top - bottom);

--- a/intervalmusiccompositor.ui.fx/src/main/java/ch/retorte/intervalmusiccompositor/ui/preferences/UiUserPreferences.java
+++ b/intervalmusiccompositor.ui.fx/src/main/java/ch/retorte/intervalmusiccompositor/ui/preferences/UiUserPreferences.java
@@ -232,7 +232,7 @@ public class UiUserPreferences extends UserPreferences {
     }
 
     private String serializeSoundEffectOccurrence(SoundEffectOccurrence soundEffectOccurrence) {
-        return soundEffectOccurrence.getSoundEffect().getId() + ":" + soundEffectOccurrence.getTimeMillis();
+        return soundEffectOccurrence.getSoundEffect().getId() + ":" + soundEffectOccurrence.getStartTimeMs();
     }
 
     private SoundEffectOccurrence deserializeSoundEffectOccurrence(String soundEffectOccurrenceString, SoundEffectsProvider soundEffectsProvider) {

--- a/intervalmusiccompositor.ui.fx/src/main/java/ch/retorte/intervalmusiccompositor/ui/soundeffects/SoundEffectEntry.java
+++ b/intervalmusiccompositor.ui.fx/src/main/java/ch/retorte/intervalmusiccompositor/ui/soundeffects/SoundEffectEntry.java
@@ -115,7 +115,7 @@ class SoundEffectEntry extends HBox {
     }
 
     private void initializeSpinner() {
-        soundEffectStartTime.getValueFactory().setValue((int) (soundEffectOccurrence.getTimeMillis() / 1000));
+        soundEffectStartTime.getValueFactory().setValue((int) (soundEffectOccurrence.getStartTimeMs() / 1000));
         soundEffectStartTime.valueProperty().addListener(debugHandlerWith(soundEffectStartTime.getId()));
         soundEffectStartTime.valueProperty().addListener((observable, oldValue, newValue) -> updateSelectedSoundEffect());
         soundEffectStartTime.valueProperty().addListener((observable, oldValue, newValue) -> parent.updatePreferences());
@@ -137,12 +137,12 @@ class SoundEffectEntry extends HBox {
     }
 
     private int getLatestStartTimeWith(int maximalTrackDuration) {
-        return maximalTrackDuration - (int) Math.ceil(soundEffectOccurrence.getSoundEffect().getDurationMillis() / 1000.0);
+        return maximalTrackDuration - (int) Math.ceil(soundEffectOccurrence.getSoundEffect().getDurationMs() / 1000.0);
     }
 
     private void updateSelectedSoundEffect() {
         soundEffectOccurrence.setSoundEffect(soundEffects.getValue());
-        soundEffectOccurrence.setTimeMillis(soundEffectStartTime.getValueFactory().getValue() * 1000);
+        soundEffectOccurrence.setStartTimeMs(soundEffectStartTime.getValueFactory().getValue() * 1000);
 
         parent.updateEntry();
     }

--- a/intervalmusiccompositor.ui.fx/src/main/java/ch/retorte/intervalmusiccompositor/ui/soundeffects/SoundEffectListCell.java
+++ b/intervalmusiccompositor.ui.fx/src/main/java/ch/retorte/intervalmusiccompositor/ui/soundeffects/SoundEffectListCell.java
@@ -40,7 +40,7 @@ public class SoundEffectListCell extends ListCell<SoundEffect> {
 
         if (item != null) {
             String itemId = item.getId();
-            double itemDurationSeconds = item.getDisplayDurationMillis() / 1000.0;
+            double itemDurationSeconds = item.getDisplayDurationMs() / 1000.0;
 
             setText(getNameFor(itemId) + " (" + formatTime.getStrictFormattedTime(itemDurationSeconds) + "s)");
         }

--- a/intervalmusiccompositor.ui.fx/src/main/java/ch/retorte/intervalmusiccompositor/ui/soundeffects/SoundEffectsPane.java
+++ b/intervalmusiccompositor.ui.fx/src/main/java/ch/retorte/intervalmusiccompositor/ui/soundeffects/SoundEffectsPane.java
@@ -129,7 +129,7 @@ public class SoundEffectsPane extends BorderPane {
 
         adaptSpinnerRangeToMusicAndBreakSize();
 
-        messageProducer.send(new DebugMessage(this, "Added sound effect '" + soundEffectOccurrence.getSoundEffect().getId() + "' at '" + soundEffectOccurrence.getTimeMillis() + "'."));
+        messageProducer.send(new DebugMessage(this, "Added sound effect '" + soundEffectOccurrence.getSoundEffect().getId() + "' at '" + soundEffectOccurrence.getStartTimeMs() + "'."));
         fireEffectChangeListener();
     }
 
@@ -143,7 +143,7 @@ public class SoundEffectsPane extends BorderPane {
         soundEffectEntries.remove(soundEffectEntry);
         soundEffectsContainer.getChildren().remove(soundEffectEntry);
 
-        messageProducer.send(new DebugMessage(this, "Removed sound effect '" + soundEffectOccurrence.getSoundEffect().getId() + "' at '" + soundEffectOccurrence.getTimeMillis() + "'."));
+        messageProducer.send(new DebugMessage(this, "Removed sound effect '" + soundEffectOccurrence.getSoundEffect().getId() + "' at '" + soundEffectOccurrence.getStartTimeMs() + "'."));
         fireEffectChangeListener();
         updatePreferences();
     }


### PR DESCRIPTION
…field (from long to double) to prevent rounding issues when converting this length into audio frames. Fixes #82.

Also, some cleanup with seconds/milliseconds.

The length in milliseconds of the double whistle sound effect is around 999.8 ms, but this was previously represented as a long field which got rounded downwards to 999 ms. When using this to calculate the audio frames we ended up with an odd number of frames which, after being inserted into the output audio stream, borked the byte order and looked like white noise in the player.